### PR TITLE
Fix version numbers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN wget https://github.com/google/protobuf/archive/v$PROTOBUF_VERSION.tar.gz -O
     rm ../protobuf.tar.gz
 
 # https://issues.apache.org/jira/browse/THRIFT-1300
-ARG THRIFT_VERSION=0.7.0
+ARG THRIFT_VERSION=0.9.3
 RUN wget https://archive.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz -O thrift.tar.gz && \
     tar xzf thrift.tar.gz && \
     cd thrift* && \

--- a/readme.md
+++ b/readme.md
@@ -17,13 +17,13 @@ Building the jars:
 ```bash
 george@george:~$ docker build -t parquet-mr docker-parquet-mr
 george@george:~$ docker run -d --name parquet-mr parquet-mr sleep 3600
-george@george:~$ docker cp parquet-mr:/parquet-mr/parquet-cli/target/parquet-cli-1.9.1-SNAPSHOT-runtime.jar ./
-george@george:~$ docker cp parquet-mr:/parquet-mr/parquet-tools/target/parquet-tools-1.9.1-SNAPSHOT.jar ./
+george@george:~$ docker cp parquet-mr:/parquet-mr/parquet-cli/target/parquet-cli-1.10.1-SNAPSHOT-runtime.jar ./
+george@george:~$ docker cp parquet-mr:/parquet-mr/parquet-tools/target/parquet-tools-1.10.1-SNAPSHOT.jar ./
 ```
 
 Using the jars:
 
 ```
-java -jar parquet-cli-1.9.1-SNAPSHOT-runtime.jar org.apache.parquet.cli.Main
-hadoop jar parquet-cli-1.9.1-SNAPSHOT-runtime.jar org.apache.parquet.cli.Main
+java -jar parquet-cli-1.10.1-SNAPSHOT-runtime.jar org.apache.parquet.cli.Main
+hadoop jar parquet-cli-1.10.1-SNAPSHOT-runtime.jar org.apache.parquet.cli.Main
 ```


### PR DESCRIPTION
Hello! Thanks for putting up this docker image. I encountered some errors while getting this setup stemming from the version update from parquet tools.

I still cannot get this working as I get the following:

```
java -jar parquet-tools-1.10.1-SNAPSHOT.jar org.apache.parquet.cli.Main
Unknown command: org.apache.parquet.cli.Main
```

I'm on a mac with the following java version.

```
java -version
java version "1.8.0_161"
Java(TM) SE Runtime Environment (build 1.8.0_161-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
```

I don't know much about the java ecosytem so I was hoping you might have the solution off the top of your head. Thanks!